### PR TITLE
Fix: Remove redundant termbox.Close call

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func startGame(board [][]int) {
 			case termbox.KeyEsc:
 				termbox.SetCursor(0, gameFieldEndY)
 				termbox.Flush()
-				termbox.Close()
 			case termbox.KeyArrowDown:
 				board = rotateBoard(board, false)
 				board = slideLeft(board)


### PR DESCRIPTION
The termbox.Close() call in startGame was redundant because it was already deferred in the main function. This change removes the extra call to prevent potential issues like double closing the terminal.