### PR TITLE
Fix ESC key to exit game

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func startGame(board [][]int) {
 			case termbox.KeyEsc:
 				termbox.SetCursor(0, gameFieldEndY)
 				termbox.Flush()
+				return
 			case termbox.KeyArrowDown:
 				board = rotateBoard(board, false)
 				board = slideLeft(board)


### PR DESCRIPTION
## Summary
- exit the event loop when ESC is pressed so the game ends cleanly

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688855b95cd483279eb8439670eba19d