### PR TITLE
Fix ESC key to exit game

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 	}
 	defer termbox.Close()
 
+	rand.Seed(time.Now().UnixNano())
+
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
 	board := initBoard(boardLen)
 	drawGameField(board)
@@ -46,9 +48,7 @@ func drawGameField(board [][]int) {
 
 func putNextNumber(board [][]int) {
 	emptyCells := findEmptyCells(board)
-	rndSrc := rand.NewSource(time.Now().UnixNano())
-	rnd := rand.New(rndSrc)
-	emptyCell := emptyCells[rnd.Intn(len(emptyCells))]
+	emptyCell := emptyCells[rand.Intn(len(emptyCells))]
 	board[emptyCell/len(board)][emptyCell%len(board)] = 2
 }
 
@@ -114,6 +114,7 @@ func startGame(board [][]int) {
 			case termbox.KeyEsc:
 				termbox.SetCursor(0, gameFieldEndY)
 				termbox.Flush()
+				return
 			case termbox.KeyArrowDown:
 				board = rotateBoard(board, false)
 				board = slideLeft(board)


### PR DESCRIPTION
## Summary
- exit the event loop when ESC is pressed so the game ends cleanly
- seed the random number generator once in `main`
- reuse the default `rand.Intn` in `putNextNumber`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688855b95cd483279eb8439670eba19d