### PR TITLE
Fix game termination handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,10 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
-const boardLen = 4
+const (
+	boardSize = 4
+	winTarget = 2048
+)
 
 var boardStartY int
 var gameFieldEndY int
@@ -22,8 +25,10 @@ func main() {
 	}
 	defer termbox.Close()
 
+	rand.Seed(time.Now().UnixNano())
+
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-	board := initBoard(boardLen)
+	board := initBoard(boardSize)
 	drawGameField(board)
 	startGame(board)
 }
@@ -39,16 +44,14 @@ func initBoard(size int) [][]int {
 func drawGameField(board [][]int) {
 	putNextNumber(board)
 	putNextNumber(board)
-	boardStartY = printTerminal(0, 0, []string{"Game 2048", ""})
+	boardStartY = printTerminal(0, 0, []string{fmt.Sprintf("Game %d", winTarget), ""})
 	boardEndY := drawBoard(0, boardStartY, board)
 	gameFieldEndY = printTerminal(0, boardEndY, []string{"Esc ←↑↓→", ""})
 }
 
 func putNextNumber(board [][]int) {
 	emptyCells := findEmptyCells(board)
-	rndSrc := rand.NewSource(time.Now().UnixNano())
-	rnd := rand.New(rndSrc)
-	emptyCell := emptyCells[rnd.Intn(len(emptyCells))]
+	emptyCell := emptyCells[rand.Intn(len(emptyCells))]
 	board[emptyCell/len(board)][emptyCell%len(board)] = 2
 }
 
@@ -64,11 +67,12 @@ func findEmptyCells(board [][]int) []int {
 	return emptyCells
 }
 
-func gameOver() {
+func gameOver() bool {
 	printTerminal(0, gameFieldEndY, []string{"Game Over!"})
 	printTerminal(0, gameFieldEndY+1, []string{"Press Esc Key to Exit"})
 	termbox.SetCursor(0, gameFieldEndY+1)
 	termbox.Flush()
+	return true
 }
 
 func printTerminal(startX, startY int, strs []string) int {
@@ -88,7 +92,7 @@ func drawBoard(startX, startY int, board [][]int) int {
 		for _, cell := range row {
 			cStr = fmt.Sprintf("%5d", cell)
 			if cell == 0 {
-				cStr = strings.Replace(cStr, "0", ".", -1)
+				cStr = strings.ReplaceAll(cStr, "0", ".")
 			}
 			str += cStr
 		}
@@ -109,21 +113,24 @@ func startGame(board [][]int) {
 			}
 		}
 		if event.Type == termbox.EventKey {
-			prevBoard := copyBoard(board)
-			switch event.Key {
-			case termbox.KeyEsc:
+			if event.Key == termbox.KeyEsc {
 				termbox.SetCursor(0, gameFieldEndY)
 				termbox.Flush()
+				return
+			}
+			prevBoard := copyBoard(board)
+			var gameFinished bool
+			switch event.Key {
 			case termbox.KeyArrowDown:
 				board = rotateBoard(board, false)
 				board = slideLeft(board)
 				board = rotateBoard(board, true)
 				notChanged := reflect.DeepEqual(prevBoard, board)
-				checkAndRefreshBoard(board, notChanged)
+				gameFinished = checkAndRefreshBoard(board, notChanged)
 			case termbox.KeyArrowLeft:
 				board = slideLeft(board)
 				notChanged := reflect.DeepEqual(prevBoard, board)
-				checkAndRefreshBoard(board, notChanged)
+				gameFinished = checkAndRefreshBoard(board, notChanged)
 			case termbox.KeyArrowRight:
 				board = rotateBoard(board, true)
 				board = rotateBoard(board, true)
@@ -131,14 +138,34 @@ func startGame(board [][]int) {
 				board = rotateBoard(board, false)
 				board = rotateBoard(board, false)
 				notChanged := reflect.DeepEqual(prevBoard, board)
-				checkAndRefreshBoard(board, notChanged)
+				gameFinished = checkAndRefreshBoard(board, notChanged)
 			case termbox.KeyArrowUp:
 				board = rotateBoard(board, true)
 				board = slideLeft(board)
 				board = rotateBoard(board, false)
 				notChanged := reflect.DeepEqual(prevBoard, board)
-				checkAndRefreshBoard(board, notChanged)
+				gameFinished = checkAndRefreshBoard(board, notChanged)
 			}
+			if gameFinished {
+				waitForEsc()
+				return
+			}
+		}
+	}
+}
+
+func waitForEsc() {
+	for {
+		event := termbox.PollEvent()
+		if event.Type == termbox.EventError {
+			if event.Err != nil {
+				panic(event.Err)
+			}
+		}
+		if event.Type == termbox.EventKey && event.Key == termbox.KeyEsc {
+			termbox.SetCursor(0, gameFieldEndY)
+			termbox.Flush()
+			return
 		}
 	}
 }
@@ -182,21 +209,24 @@ func slideLeft(board [][]int) [][]int {
 	return board
 }
 
-func checkAndRefreshBoard(board [][]int, boardNotChanged bool) {
-	checkWinOrLose(board)
+func checkAndRefreshBoard(board [][]int, boardNotChanged bool) bool {
+	if checkWinOrLose(board) {
+		return true
+	}
 	if !boardNotChanged {
 		putNextNumber(board)
 	}
 	drawBoard(0, boardStartY, board)
+	return false
 }
 
-func checkWinOrLose(board [][]int) {
+func checkWinOrLose(board [][]int) bool {
 	gameOverCount := 0
 	for i, row := range board {
 		for j, cell := range row {
-			if cell == 2048 {
+			if cell == winTarget {
 				drawBoard(0, boardStartY, board)
-				gameWin()
+				return gameWin()
 			}
 
 			if noPositionToMove(i, j, cell, board) {
@@ -205,9 +235,10 @@ func checkWinOrLose(board [][]int) {
 		}
 	}
 
-	if gameOverCount == boardLen*boardLen {
-		gameOver()
+	if gameOverCount == boardSize*boardSize {
+		return gameOver()
 	}
+	return false
 }
 
 func noPositionToMove(i, j, cell int, board [][]int) bool {
@@ -235,11 +266,12 @@ func noPositionToMove(i, j, cell int, board [][]int) bool {
 	return true
 }
 
-func gameWin() {
+func gameWin() bool {
 	printTerminal(0, gameFieldEndY, []string{"You Won!"})
 	printTerminal(0, gameFieldEndY+1, []string{"Press Esc Key to Exit"})
 	termbox.SetCursor(0, gameFieldEndY+1)
 	termbox.Flush()
+	return true
 }
 
 func copyBoard(board [][]int) [][]int {

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func drawBoard(startX, startY int, board [][]int) int {
 }
 
 func startGame(board [][]int) {
+	gameFinished := false
 	for {
 		event := termbox.PollEvent()
 		if event.Type == termbox.EventError {
@@ -118,8 +119,10 @@ func startGame(board [][]int) {
 				termbox.Flush()
 				return
 			}
+			if gameFinished {
+				continue
+			}
 			prevBoard := copyBoard(board)
-			var gameFinished bool
 			switch event.Key {
 			case termbox.KeyArrowDown:
 				board = rotateBoard(board, false)
@@ -150,22 +153,6 @@ func startGame(board [][]int) {
 				waitForEsc()
 				return
 			}
-		}
-	}
-}
-
-func waitForEsc() {
-	for {
-		event := termbox.PollEvent()
-		if event.Type == termbox.EventError {
-			if event.Err != nil {
-				panic(event.Err)
-			}
-		}
-		if event.Type == termbox.EventKey && event.Key == termbox.KeyEsc {
-			termbox.SetCursor(0, gameFieldEndY)
-			termbox.Flush()
-			return
 		}
 	}
 }
@@ -282,4 +269,20 @@ func copyBoard(board [][]int) [][]int {
 	}
 
 	return newBoard
+}
+
+func waitForEsc() {
+	for {
+		event := termbox.PollEvent()
+		if event.Type == termbox.EventError {
+			if event.Err != nil {
+				panic(event.Err)
+			}
+		}
+		if event.Type == termbox.EventKey && event.Key == termbox.KeyEsc {
+			termbox.SetCursor(0, gameFieldEndY)
+			termbox.Flush()
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- exit the event loop when ESC is pressed so the game ends cleanly
- seed the random number generator once in `main`
- use `strings.ReplaceAll` for clearer board rendering
- stop processing input after a win or game over, requiring ESC to exit
- define board size and winning target as constants for easier maintenance

## Testing
- `go vet -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688855b95cd483279eb8439670eba19d